### PR TITLE
Update JNoSQL version to 1.1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <datafaker.version>2.4.3</datafaker.version>
         <assertj.version>3.24.2</assertj.version>
         <testcontainers.version>2.0.2</testcontainers.version>
-        <jnosql.version>1.1.10</jnosql.version>
+        <jnosql.version>1.1.11</jnosql.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This pull request updates the version of a dependency in the project configuration to ensure compatibility and access to the latest features and fixes.

Dependency version update:

* Increased the `jnosql.version` property from `1.1.10` to `1.1.11` in `pom.xml` to use the latest release of the JNoSQL library.