### PR TITLE
Update and prepare the release of the version 3.4.13

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 3.4.12
-  next-version: 3.4.13-SNAPSHOT
+  current-version: 3.4.13
+  next-version: 3.4.14-SNAPSHOT


### PR DESCRIPTION
This pull request updates the project release version numbers in the `.github/project.yml` file.

- Bumped `current-version` to `3.4.13` and set `next-version` to `3.4.14-SNAPSHOT` in `.github/project.yml`