### PR TITLE
Fix #423: Exclude jnosql-mapping-reflection dependency from JNoSQL modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,36 +110,33 @@ The following example enables parameter metadata, sets the Java release version,
 
 ```xml
 <project>
-<!-- skipping other elements -->
-<project>
-    <!-- skipping other elements -->
-<build>
-    <plugins>
-        <!-- skipping other plugins -->
-        <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${compiler-plugin.version}</version>
-            <configuration>
-                <release>${maven.compiler.release}</release>
-                <parameters>true</parameters>
-                <annotationProcessors>
-                    <annotationProcessor>org.eclipse.jnosql.lite.mapping.EntityProcessor</annotationProcessor>
-                    <annotationProcessor>org.eclipse.jnosql.lite.mapping.repository.RepositoryProcessor</annotationProcessor>
-                </annotationProcessors>
-                <annotationProcessorPaths>
-                    <path>
-                        <groupId>org.eclipse.jnosql.lite</groupId>
-                        <artifactId>mapping-lite-processor</artifactId>
-                        <version>${jnosql-lite-processor.version}</version>
-                    </path>
-                </annotationProcessorPaths>
-            </configuration>
-        </plugin>
-        <!-- skipping other plugins -->
-    </plugins>
-</build>
-
-<!-- skipping other elements -->
+  <!-- skipping other elements -->
+  <build>
+      <plugins>
+          <!-- skipping other plugins -->
+          <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>${compiler-plugin.version}</version>
+              <configuration>
+                  <release>${maven.compiler.release}</release>
+                  <parameters>true</parameters>
+                  <annotationProcessors>
+                      <annotationProcessor>org.eclipse.jnosql.lite.mapping.EntityProcessor</annotationProcessor>
+                      <annotationProcessor>org.eclipse.jnosql.lite.mapping.repository.RepositoryProcessor</annotationProcessor>
+                  </annotationProcessors>
+                  <annotationProcessorPaths>
+                      <path>
+                          <groupId>org.eclipse.jnosql.lite</groupId>
+                          <artifactId>mapping-lite-processor</artifactId>
+                          <version>${jnosql-lite-processor.version}</version>
+                      </path>
+                  </annotationProcessorPaths>
+              </configuration>
+          </plugin>
+          <!-- skipping other plugins -->
+      </plugins>
+  </build>
+  <!-- skipping other elements -->
 </project>
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,10 +155,20 @@ The processor is provided by the `org.eclipse.jnosql.lite:mapping-lite-processor
 
 Before setting the processor version, check the latest available [`org.eclipse.jnosql.lite:mapping-lite-processor` on Maven Central](https://central.sonatype.com/artifact/org.eclipse.jnosql.lite/mapping-lite-processor).
 
+> :memo: **IMPORTANT:** When using the JNoSQL Lite annotation processor with Gradle, exclude the `jnosql-mapping-reflection` module to prevent CDI bean conflicts. In extension versions **3.4.15 and earlier**, this module is pulled in transitively, causing both the reflection-based and Lite `EntitiesMetadata` implementations to be registered as CDI beans. Without this exclusion, the application fails with an `AmbiguousResolutionException`.
+> For additional details and the current status of this issue, see GitHub issue [#423](https://github.com/quarkiverse/quarkus-jnosql/issues/423).
+
 #### Groovy DSL (build.gradle):
 ```groovy
 dependencies {
   annotationProcessor "org.eclipse.jnosql.lite:mapping-lite-processor:${jnosqlLiteProcessorVersion}"
+}
+
+// Exclude the reflection-based metadata implementation when using JNoSQL Lite.
+// Otherwise, both reflection and Lite implementations become CDI beans,
+// resulting in an AmbiguousResolutionException.
+configurations.configureEach {
+  exclude group: 'org.eclipse.jnosql.mapping', module: 'jnosql-mapping-reflection'
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -173,6 +183,16 @@ tasks.withType(JavaCompile).configureEach {
 ```kotlin
 dependencies {
   annotationProcessor("org.eclipse.jnosql.lite:mapping-lite-processor:${jnosqlLiteProcessorVersion}")
+}
+
+// Exclude the reflection-based metadata implementation when using JNoSQL Lite.
+// Otherwise, both reflection and Lite implementations become CDI beans,
+// resulting in an AmbiguousResolutionException.
+configurations.configureEach {
+  exclude(
+    group = "org.eclipse.jnosql.mapping",
+    module = "jnosql-mapping-reflection"
+  )
 }
 
 tasks.withType < JavaCompile > ().configureEach {

--- a/cassandra/runtime/pom.xml
+++ b/cassandra/runtime/pom.xml
@@ -32,6 +32,12 @@
         <dependency>
             <groupId>org.eclipse.jnosql.databases</groupId>
             <artifactId>jnosql-cassandra</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.lite</groupId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.jnosql</groupId>
@@ -16,6 +17,12 @@
         <dependency>
             <groupId>org.eclipse.jnosql.mapping</groupId>
             <artifactId>jnosql-mapping-semistructured</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.mapping</groupId>
@@ -30,6 +37,12 @@
         <dependency>
             <groupId>org.eclipse.jnosql.mapping</groupId>
             <artifactId>jnosql-mapping-key-value</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>
@@ -45,7 +58,8 @@
                             <goal>extension-descriptor</goal>
                         </goals>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
                         </configuration>
                     </execution>
                 </executions>

--- a/couchdb/runtime/pom.xml
+++ b/couchdb/runtime/pom.xml
@@ -37,6 +37,12 @@
         <dependency>
             <groupId>org.eclipse.jnosql.databases</groupId>
             <artifactId>jnosql-couchdb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.lite</groupId>

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -203,38 +203,35 @@ The following example enables parameter metadata, sets the Java release version,
 [source,xml]
 ----
 <project>
-<!-- skipping other elements -->
-<project>
     <!-- skipping other elements -->
-<build>
-    <plugins>
-        <!-- skipping other plugins -->
+    <build>
+        <plugins>
+            <!-- skipping other plugins -->
 
-        <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${compiler-plugin.version}</version>
-            <configuration>
-                <release>${maven.compiler.release}</release>
-                <parameters>true</parameters>
-                <annotationProcessors>
-                    <annotationProcessor>org.eclipse.jnosql.lite.mapping.EntityProcessor</annotationProcessor>
-                    <annotationProcessor>org.eclipse.jnosql.lite.mapping.repository.RepositoryProcessor</annotationProcessor>
-                </annotationProcessors>
-                <annotationProcessorPaths>
-                    <path>
-                        <groupId>org.eclipse.jnosql.lite</groupId>
-                        <artifactId>mapping-lite-processor</artifactId>
-                        <version>${jnosql-lite-processor.version}</version>
-                    </path>
-                </annotationProcessorPaths>
-            </configuration>
-        </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <parameters>true</parameters>
+                    <annotationProcessors>
+                        <annotationProcessor>org.eclipse.jnosql.lite.mapping.EntityProcessor</annotationProcessor>
+                        <annotationProcessor>org.eclipse.jnosql.lite.mapping.repository.RepositoryProcessor</annotationProcessor>
+                    </annotationProcessors>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.eclipse.jnosql.lite</groupId>
+                            <artifactId>mapping-lite-processor</artifactId>
+                            <version>${jnosql-lite-processor.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
 
-        <!-- skipping other plugins -->
-    </plugins>
-</build>
-
-<!-- skipping other elements -->
+            <!-- skipping other plugins -->
+        </plugins>
+    </build>
+    <!-- skipping other elements -->
 </project>
 ----
 
@@ -248,9 +245,15 @@ The target build tool for the Quarkus JNoSQL Extension is Maven. However, if you
 
 The processor is provided by the `org.eclipse.jnosql.lite:mapping-lite-processor` dependency.
 
-Before setting the processor version, check the latest available version on Maven Central:
+Before setting the processor version, check the latest available version on Maven Central: https://central.sonatype.com/artifact/org.eclipse.jnosql.lite/mapping-lite-processor[`org.eclipse.jnosql.lite:mapping-lite-processor` on Maven Central]
 
-https://central.sonatype.com/artifact/org.eclipse.jnosql.lite/mapping-lite-processor[`org.eclipse.jnosql.lite:mapping-lite-processor` on Maven Central]
+[IMPORTANT]
+====
+When using the JNoSQL Lite annotation processor with Gradle, exclude the `jnosql-mapping-reflection` module to prevent CDI bean conflicts. In extension versions **3.4.15 and earlier**, this module is pulled in transitively, causing both the reflection-based and Lite `EntitiesMetadata` implementations to be registered as CDI beans. Without this exclusion, the application fails with an `AmbiguousResolutionException`.
+
+For additional details and the current status of this issue, see GitHub issue https://github.com/quarkiverse/quarkus-jnosql/issues/423[#423].
+
+====
 
 ==== Groovy DSL (`build.gradle`)
 
@@ -258,6 +261,13 @@ https://central.sonatype.com/artifact/org.eclipse.jnosql.lite/mapping-lite-proce
 ----
 dependencies {
     annotationProcessor "org.eclipse.jnosql.lite:mapping-lite-processor:${jnosqlLiteProcessorVersion}"
+}
+
+// Exclude the reflection-based metadata implementation when using JNoSQL Lite.
+// Otherwise, both reflection and Lite implementations become CDI beans,
+// resulting in an AmbiguousResolutionException.
+configurations.configureEach {
+ exclude group: 'org.eclipse.jnosql.mapping', module: 'jnosql-mapping-reflection'
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -269,13 +279,21 @@ tasks.withType(JavaCompile).configureEach {
 ----
 
 ==== Kotlin DSL (`build.gradle.kts`)
-
 [source,kotlin]
 ----
 dependencies {
     annotationProcessor("org.eclipse.jnosql.lite:mapping-lite-processor:${jnosqlLiteProcessorVersion}")
 }
 
+// Exclude the reflection-based metadata implementation when using JNoSQL Lite.
+// Otherwise, both reflection and Lite implementations become CDI beans,
+// resulting in an AmbiguousResolutionException.
+configurations.configureEach {
+    exclude(
+        group = "org.eclipse.jnosql.mapping",
+        module = "jnosql-mapping-reflection"
+    )
+}
 tasks.withType < JavaCompile > ().configureEach {
     options.compilerArgs.addAll(
         listOf(

--- a/mongodb/runtime/pom.xml
+++ b/mongodb/runtime/pom.xml
@@ -33,6 +33,12 @@
         <dependency>
             <groupId>org.eclipse.jnosql.databases</groupId>
             <artifactId>jnosql-mongodb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.lite</groupId>

--- a/neo4j/runtime/pom.xml
+++ b/neo4j/runtime/pom.xml
@@ -32,6 +32,12 @@
         <dependency>
             <groupId>org.eclipse.jnosql.databases</groupId>
             <artifactId>jnosql-neo4j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.lite</groupId>

--- a/solr/runtime/pom.xml
+++ b/solr/runtime/pom.xml
@@ -29,6 +29,12 @@
         <dependency>
             <groupId>org.eclipse.jnosql.databases</groupId>
             <artifactId>jnosql-solr</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.lite</groupId>


### PR DESCRIPTION

## Summary
Fixes #423 — excludes the  dependency from the JNoSQL extension modules, preventing  for  when using the jnosql-lite annotation processor with Gradle.

## Details
When using Gradle (unlike Maven), the transitive dependency graph causes both the reflection-based and Lite `EntitiesMetadata` implementations to be present as CDI beans, leading to an ambiguous resolution.

This PR removes the reflection-based mapping dependency from the JNoSQL runtime modules, so that only the lite metadata implementation is available at build time.

## Changes
- Exclude `jnosql-mapping-reflection` dependency from Quarkus JNoSQL modules
- Updated documentation for Gradle configuration
- Updated README with explicit configuration notes

## Related
Closes #423
