### PR TITLE
chore(project): bump version to 3.4.16

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 3.4.15
-  next-version: 3.4.16-SNAPSHOT
+  current-version: 3.4.16
+  next-version: 3.4.17-SNAPSHOT


### PR DESCRIPTION
Bumps project version to 3.4.16 and sets next snapshot to 3.4.17-SNAPSHOT.