### PR TITLE
chore: update project version to 3.5.1 and set next version to 3.5.2-…

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 3.5.0
-  next-version: 3.5.1-SNAPSHOT
+  current-version: 3.5.1
+  next-version: 3.5.2-SNAPSHOT


### PR DESCRIPTION
This pull request updates the release version numbers in the `.github/project.yml` file to reflect a new release.

- Bumped the `current-version` from `3.5.0` to `3.5.1` and updated the `next-version` to `3.5.2-SNAPSHOT` in `.github/project.yml`